### PR TITLE
require 'aws' to create client for saving screenshots

### DIFF
--- a/lib/click_session/s3_connection.rb
+++ b/lib/click_session/s3_connection.rb
@@ -1,3 +1,5 @@
+require "aws"
+
 module ClickSession
   class S3Connection
     attr_reader :bucket_name

--- a/spec/click_session/s3_connection_spec.rb
+++ b/spec/click_session/s3_connection_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+class ClientStub
+  def buckets
+    { "unit-bucket" => BucketStub.new }
+  end
+end
+
+class BucketStub
+  def objects
+    { "filename" => ObjectStub.new }
+  end
+end
+
+class ObjectStub
+  def write(path, options)
+
+  end
+end
+
+describe ClickSession::S3Connection do
+  describe "#upload_from_filesystem_to_bucket" do
+    it "uploads the file to an S3 bucket" do
+      key_id = "unit-key-id"
+      access_key = "unit-access-key"
+      bucket_name = "unit-bucket"
+      aws_client_stub = ClientStub.new
+      allow(AWS::S3).to receive(:new).and_return(aws_client_stub)
+      connection = ClickSession::S3Connection.new(key_id, access_key, bucket_name)
+
+      connection.upload_from_filesystem_to_bucket("filename", "/some/path")
+
+      expect(AWS::S3).
+        to have_received(:new).
+        with(access_key_id: key_id, secret_access_key: access_key).
+        once
+    end
+  end
+end


### PR DESCRIPTION
There was no require statement for the `aws` client, so I added it.

I also added a test case to ensure that the client is correctly loaded.
